### PR TITLE
Support typing code directly and using prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Hacked this together in a couple hours, so PRs or suggestions are welcome.
 * libnotify
 * yubikey-manager (ykman)
 * xclip
+* xdotool
 
 ## Installation
 
@@ -30,5 +31,11 @@ Or, on anything else:
 ## Usage
 
 Simply search for the account name, then hit enter (or click) to copy the code.
+Code can also be typed automatically in the active window by set `type: True` and `copy: False` in the user specific config file ~/.config/yubioath-krunner/settings.cfg
+or system wide in /etc/yubioath-krunner/settings.cfg
+
+You can also set a prefix word in the settings.cfg to trigger search. This can be useful if you don't want to clutter krunner search menu
 
 **Hot tip:** If you've added a new account, just copy a code from any account to refresh the credential list.
+
+**Wayland users:** If you are using Wayland, directly typing code with xdotool won't work because it's doesn't support Wayland.

--- a/install.sh
+++ b/install.sh
@@ -2,5 +2,7 @@ PREFIX=${PREFIX:-~/.local}
 echo $PREFIX
 mkdir -p $PREFIX/share/kservices5
 mkdir -p ~/.config/autostart-scripts
+mkdir -p ~/.config/yubioath-krunner
 cp yubioath-krunner.desktop $PREFIX/share/kservices5
 cp yubioath-krunner.py ~/.config/autostart-scripts
+cp ./settings.cfg ~/.config/yubioath-krunner

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+dbus-python==1.2.12
+fuzzywuzzy==0.17.0
+gobject==0.1.0
+PyGObject==3.34.0
+python-Levenshtein==0.12.0
+ConfigArgParse==0.15.2

--- a/settings.cfg
+++ b/settings.cfg
@@ -1,6 +1,6 @@
 # Prefix that need to be typed to trigger yubikey code search
 # Can be set to mfa for example
-prefix: ""
+# prefix: mfa
 
 # Enable or disable copying codes to clipboard
 copy: True

--- a/settings.cfg
+++ b/settings.cfg
@@ -1,0 +1,9 @@
+# Prefix that need to be typed to trigger yubikey code search
+# Can be set to mfa for example
+prefix: ""
+
+# Enable or disable copying codes to clipboard
+copy: True
+
+# Enable or disable typing codes directly into the active window
+type: False

--- a/yubioath-krunner.py
+++ b/yubioath-krunner.py
@@ -5,6 +5,11 @@ import re
 from fuzzywuzzy import process
 import subprocess
 from dbus.mainloop.glib import DBusGMainLoop
+import configargparse
+from pprint import pprint
+
+APP_NAME = "yubioath-krunner"
+CONFIG_FILE_NAME = "settings.cfg"
 
 DBusGMainLoop(set_as_default=True)
 
@@ -12,7 +17,8 @@ objpath="/yubioath"
 
 iface="org.kde.krunner1"
 class Runner(dbus.service.Object):
-    def __init__(self):
+    def __init__(self, options):
+        self.options = options
         self.credentials = self.get_credentials()
         dbus.service.Object.__init__(self, dbus.service.BusName("me.odensc.yubioath", dbus.SessionBus()), objpath)
 
@@ -38,6 +44,10 @@ class Runner(dbus.service.Object):
 
     @dbus.service.method(iface, in_signature='s', out_signature='a(sssida{sv})')
     def Match(self, query):
+        if options.prefix and query[0:len(options.prefix)-1] == options.prefix:
+            query = query[len(options.prefix):]
+        else:
+            return []
         fuzzy_credentials = process.extract(query, [cred["id"] for cred in self.credentials], limit=3)
         results = []
 
@@ -52,13 +62,23 @@ class Runner(dbus.service.Object):
     @dbus.service.method(iface, in_signature='ss')
     def Run(self, matchId, actionId):
         code = self.get_code(matchId)
-        subprocess.run("echo -n '{}' | xclip -selection clipboard".format(code), shell=True)
-        subprocess.run(["notify-send", "--urgency=low", "--expire-time=2000", "--icon=nm-vpn-active-lock", "YubiOATH", "Code copied to clipboard"])
+        if self.options.copy:
+            subprocess.run("echo -n '{}' | xclip -selection clipboard".format(code), shell=True)
+            subprocess.run(["notify-send", "--urgency=low", "--expire-time=2000", "--icon=nm-vpn-active-lock", "YubiOATH", "Code copyed to clipboard!"])
+        if self.options.type:
+            subprocess.run(f"xdotool type {code}", shell=True)
+            subprocess.run(["notify-send", "--urgency=low", "--expire-time=2000", "--icon=nm-vpn-active-lock", "YubiOATH", "Code typed!"])
         # Refresh credentials.
         self.credentials = self.get_credentials()
 
         return
 
-runner = Runner()
+config = configargparse.ArgParser(default_config_files=[f'/etc/{APP_NAME}/{CONFIG_FILE_NAME}', f'./{CONFIG_FILE_NAME}', f'~/.config/{APP_NAME}/{CONFIG_FILE_NAME}'])
+config.add('--prefix', default="", help='Prefix used to search in krunner')
+config.add('--copy', action='store_true', help='Copy code to clipboard')
+config.add('--type', action='store_true', help='Type code in active window')
+options = config.parse_args()
+
+runner = Runner(options)
 loop = GLib.MainLoop()
 loop.run()

--- a/yubioath-krunner.py
+++ b/yubioath-krunner.py
@@ -6,7 +6,6 @@ from fuzzywuzzy import process
 import subprocess
 from dbus.mainloop.glib import DBusGMainLoop
 import configargparse
-from pprint import pprint
 
 APP_NAME = "yubioath-krunner"
 CONFIG_FILE_NAME = "settings.cfg"
@@ -44,10 +43,11 @@ class Runner(dbus.service.Object):
 
     @dbus.service.method(iface, in_signature='s', out_signature='a(sssida{sv})')
     def Match(self, query):
-        if options.prefix and query[0:len(options.prefix)-1] == options.prefix:
+        if query[0:len(self.options.prefix)] == self.options.prefix:
             query = query[len(options.prefix):]
         else:
             return []
+
         fuzzy_credentials = process.extract(query, [cred["id"] for cred in self.credentials], limit=3)
         results = []
 


### PR DESCRIPTION
The goal of this PR is to adds the following:

1- Ability to type codes directly in the active window using xdotool
2- Ability to use a prefix before matching codes

1 and 2 are configurable using `settings.cfg` that can be read from current directory, `~/.config/yubioth-krunner/` or `/etc/yubioth-krunner/`

They can be set using command line flags: `--type`, `--copy` and `--prefix` too.

I have also added a `requirements.txt` to make development easier.

Thank you for considering this PR!
  